### PR TITLE
Paths on DAGs

### DIFF
--- a/dagology/__init__.py
+++ b/dagology/__init__.py
@@ -3,3 +3,4 @@ from .generators import *
 from .utils import *
 from .metrics import *
 from .matrix import *
+from .paths import *

--- a/dagology/paths/__init__.py
+++ b/dagology/paths/__init__.py
@@ -1,0 +1,1 @@
+from .paths import *

--- a/dagology/paths/paths.py
+++ b/dagology/paths/paths.py
@@ -1,0 +1,15 @@
+__author__ = "\n".join(["Nicolas Kozak (nicolas.kozak5@gmail.com)"])
+
+
+def shortest_path(node, weights, distances, predecessors):
+    for v, w in weights.items():
+        new_distance = distances[node] + w
+        if distances[v] > new_distance:
+            distances[v], predecessors[v] = new_distance, node
+
+
+def longest_path(node, weights, distances, predecessors):
+    for v, w in weights.items():
+        new_distance = distances[node] - w
+        if distances[v] > new_distance:
+            distances[v], predecessors[v] = new_distance, node

--- a/dagology/paths/paths.py
+++ b/dagology/paths/paths.py
@@ -13,3 +13,19 @@ def longest_path(node, weights, distances, predecessors):
         new_distance = distances[node] - w
         if distances[v] > new_distance:
             distances[v], predecessors[v] = new_distance, node
+
+def greedy_shortest_path(node, weights, distances, predecessors):
+    if weights:
+        min_neighbor = min(weights, key=weights.get)
+        new_distance = distances[node] + weights[min_neighbor]
+        if distances[min_neighbor] > new_distance:
+            distances[min_neighbor] = new_distance
+            predecessors[min_neighbor] = node
+
+def greedy_longest_path(node, weights, distances, predecessors):
+    if weights:
+        max_neighbor = max(weights, key=weights.get)
+        new_distance = distances[node] - weights[max_neighbor]
+        if distances[max_neighbor] > new_distance:
+            distances[max_neighbor] = new_distance
+            predecessors[max_neighbor] = node

--- a/examples/diagrams/causal_set.ipynb
+++ b/examples/diagrams/causal_set.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-03-24T12:20:45.612535Z",
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-03-24T12:20:45.619000Z",
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-03-24T12:20:45.817906Z",
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-03-24T12:20:46.019540Z",
@@ -77,15 +77,29 @@
     "deletable": true,
     "editable": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 1, 3, 5, 9]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "G = dag.CausalSetGraph().generate_graph(R, weighted=True)\n",
-    "G_TR = nx.transitive_reduction(G)"
+    "DAG = dag.CausalSetGraph()\n",
+    "G = DAG.generate_graph(R, weighted=True)\n",
+    "G_TR = nx.transitive_reduction(G)\n",
+    "\n",
+    "DAG.traverse_path(dag.shortest_path, 'forward')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-03-24T12:20:46.248029Z",

--- a/examples/diagrams/causal_set.ipynb
+++ b/examples/diagrams/causal_set.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-03-24T12:20:45.612535Z",
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-03-24T12:20:45.619000Z",
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-03-24T12:20:45.817906Z",
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-03-24T12:20:46.019540Z",
@@ -81,10 +81,10 @@
     {
      "data": {
       "text/plain": [
-       "[0, 1, 3, 5, 9]"
+       "[0, 1, 2, 7, 9]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -94,12 +94,12 @@
     "G = DAG.generate_graph(R, weighted=True)\n",
     "G_TR = nx.transitive_reduction(G)\n",
     "\n",
-    "DAG.traverse_path(dag.shortest_path, 'forward')"
+    "DAG.traverse_path(dag.greedy_shortest_path, 'forward')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-03-24T12:20:46.248029Z",


### PR DESCRIPTION
Added a traverse_path method to abstract DAG class which allows to traverse the DAG in topological order either forward or backward
Created paths.py, which contains different update rules for different types of path. An example of how this works can be seen in causal_set.ipynb